### PR TITLE
Scaffold Next.js 15 App Router + Payload CMS architecture for APP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+NODE_ENV=development
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app
+PAYLOAD_SECRET=replace-with-strong-secret
+S3_MEDIA_BUCKET=app-media-dev
+S3_ESTIMATES_BUCKET=app-estimates-dev
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+SES_FROM_EMAIL=no-reply@mailer.andersonpropertypreservation.com
+GA_MEASUREMENT_ID=
+RECAPTCHA_SECRET_KEY=
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.env
+.env.*
+!.env.example
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+coverage
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,9 +1,64 @@
-# hello-world
-This is my first GitHub project
-I am a fairly new web developer. I am submersing myself in code, code, code. I am setting out to master javaScript, python, Ruby, and some I don't know about yet. Oh, and many of the frameworks out there. Once I get a good grasp, I'd like to author a framework to use. 
+# Anderson Property Preservation (APP)
 
-My company is kreativ beetle media development. I will master digital and creative media. These are important to communication in the world, just as body language is. Communication media IS the global body language.
+Production scaffold for **Next.js + Payload CMS + Tailwind** aligned to APP architecture.
 
-More than that, I want to contribute as much as possible to the world. I believe communication, expression of self, is the basis for freedom - within and without. I'd like to help facilitate this for all people. The universe is abundant. There's more than enough abundancy for ALL people to share and partake.
+## Stack pins
 
-Peace.
+- Node.js 20.x
+- Next.js 15.4.x
+- Payload CMS 3.x (Next.js-compatible)
+- PostgreSQL (RDS target)
+- S3 (media + estimate uploads)
+- SES (transactional email)
+
+## Quick start
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Copy env file
+   ```bash
+   cp .env.example .env.local
+   ```
+3. Run dev server
+   ```bash
+   npm run dev
+   ```
+
+## Route scaffold
+
+The following public routes are scaffolded in the App Router:
+
+- `/`
+- `/services`
+- `/property-cleanouts-columbus-ga`
+- `/junk-removal-columbus-ga`
+- `/lawn-overgrowth-cleanup-columbus-ga`
+- `/rental-turnover-cleanup-columbus-ga`
+- `/property-managers-investors`
+- `/service-areas`
+- `/service-areas/columbus-muscogee`
+- `/service-areas/harris-county-ga`
+- `/service-areas/russell-county-al`
+- `/before-after-gallery`
+- `/about`
+- `/request-estimate`
+- `/thank-you`
+- `/privacy-policy`
+
+## Payload scaffold status
+
+Implemented collections/globals:
+
+- collections: `users`, `media`, `pages`, `services`, `serviceAreas`, `galleryItems`, `reviews`, `faqs`, `estimateSubmissions`
+- globals: `siteSettings`, `headerSettings`, `footerSettings`, `homepage`
+
+## Next implementation milestones
+
+1. Complete Payload official Next admin route wiring.
+2. Add dynamic page rendering from Payload docs.
+3. Implement S3 pre-signed upload flow in `app/api/uploads/presign/route.ts`.
+4. Implement estimate save + SES notifications in `app/api/estimates/route.ts`.
+5. Add SEO utilities (metadata, sitemap, robots, schema).
+6. Add analytics events and spam protection.

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">about</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/before-after-gallery/page.tsx
+++ b/app/(site)/before-after-gallery/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">before after gallery</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/junk-removal-columbus-ga/page.tsx
+++ b/app/(site)/junk-removal-columbus-ga/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">junk removal columbus ga</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/lawn-overgrowth-cleanup-columbus-ga/page.tsx
+++ b/app/(site)/lawn-overgrowth-cleanup-columbus-ga/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">lawn overgrowth cleanup columbus ga</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,0 +1,5 @@
+import { SiteShell } from '@/components/site-shell'
+
+export default function SiteLayout({ children }: { children: React.ReactNode }) {
+  return <SiteShell>{children}</SiteShell>
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <section id="home-hero" className="mx-auto max-w-6xl px-4 py-16 md:px-8 md:py-24">
+      <p className="text-sm uppercase tracking-[0.2em] text-[var(--color-forest)]">Anderson Property Preservation</p>
+      <h1 className="mt-3 text-5xl font-semibold leading-tight">Premium property cleanup and preservation services.</h1>
+      <p className="mt-6 max-w-2xl text-lg text-black/75">
+        Production scaffold is live with Next.js App Router, Tailwind tokens, and Payload-ready architecture.
+      </p>
+      <div className="mt-8 flex flex-wrap gap-4">
+        <Link href="/request-estimate" className="rounded-[var(--radius-card)] bg-[var(--color-forest)] px-6 py-3 text-white">
+          Request Estimate
+        </Link>
+        <Link href="/services" className="rounded-[var(--radius-card)] border border-[var(--color-stone)] px-6 py-3">
+          View Services
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/app/(site)/privacy-policy/page.tsx
+++ b/app/(site)/privacy-policy/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">privacy policy</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/property-cleanouts-columbus-ga/page.tsx
+++ b/app/(site)/property-cleanouts-columbus-ga/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">property cleanouts columbus ga</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/property-managers-investors/page.tsx
+++ b/app/(site)/property-managers-investors/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">property managers investors</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/rental-turnover-cleanup-columbus-ga/page.tsx
+++ b/app/(site)/rental-turnover-cleanup-columbus-ga/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">rental turnover cleanup columbus ga</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/request-estimate/page.tsx
+++ b/app/(site)/request-estimate/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">request estimate</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/service-areas/columbus-muscogee/page.tsx
+++ b/app/(site)/service-areas/columbus-muscogee/page.tsx
@@ -1,0 +1,8 @@
+export default function ServiceAreaPage() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">columbus muscogee</h1>
+      <p className="mt-4 text-black/75">Localized service-area page scaffold.</p>
+    </section>
+  )
+}

--- a/app/(site)/service-areas/harris-county-ga/page.tsx
+++ b/app/(site)/service-areas/harris-county-ga/page.tsx
@@ -1,0 +1,8 @@
+export default function ServiceAreaPage() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">harris county ga</h1>
+      <p className="mt-4 text-black/75">Localized service-area page scaffold.</p>
+    </section>
+  )
+}

--- a/app/(site)/service-areas/page.tsx
+++ b/app/(site)/service-areas/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+const areas = [
+  { href: '/service-areas/columbus-muscogee', label: 'Columbus / Muscogee' },
+  { href: '/service-areas/harris-county-ga', label: 'Harris County, GA' },
+  { href: '/service-areas/russell-county-al', label: 'Russell County, AL' },
+]
+
+export default function ServiceAreasPage() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold">Service Areas</h1>
+      <ul className="mt-8 space-y-3">
+        {areas.map((area) => (
+          <li key={area.href}>
+            <Link href={area.href} className="text-[var(--color-forest)] underline">
+              {area.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/app/(site)/service-areas/russell-county-al/page.tsx
+++ b/app/(site)/service-areas/russell-county-al/page.tsx
@@ -1,0 +1,8 @@
+export default function ServiceAreaPage() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">russell county al</h1>
+      <p className="mt-4 text-black/75">Localized service-area page scaffold.</p>
+    </section>
+  )
+}

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">services</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/(site)/thank-you/page.tsx
+++ b/app/(site)/thank-you/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+      <h1 className="text-4xl font-semibold capitalize">thank you</h1>
+      <p className="mt-4 text-black/75">Scaffolded route for APP architecture buildout.</p>
+    </section>
+  )
+}

--- a/app/admin/[[...segments]]/page.tsx
+++ b/app/admin/[[...segments]]/page.tsx
@@ -1,0 +1,15 @@
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+export default async function PayloadAdmin() {
+  await getPayload({ config: configPromise })
+
+  return (
+    <section className="mx-auto max-w-4xl px-4 py-16">
+      <h1 className="text-4xl font-semibold">Payload Admin</h1>
+      <p className="mt-4 text-black/75">
+        Payload admin wiring is scaffolded. Add official Payload Next route handlers/components to complete integration.
+      </p>
+    </section>
+  )
+}

--- a/app/api/estimates/route.ts
+++ b/app/api/estimates/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  return NextResponse.json(
+    {
+      message: 'Estimate submission endpoint scaffolded. Persist to Payload collection and trigger SES notification.',
+    },
+    { status: 501 },
+  )
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', service: 'anderson-property-preservation' })
+}

--- a/app/api/uploads/presign/route.ts
+++ b/app/api/uploads/presign/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  return NextResponse.json(
+    {
+      message: 'Presign endpoint scaffolded. Implement AWS SDK v3 S3 pre-signed URLs with auth, mime checks, and size caps.',
+    },
+    { status: 501 },
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,30 @@
+@import "tailwindcss";
+
+:root {
+  --color-charcoal: #1f2329;
+  --color-forest: #2f4736;
+  --color-gold: #b59a5a;
+  --color-ivory: #f7f5f0;
+  --color-stone: #d8d1c5;
+  --radius-card: 0.875rem;
+}
+
+body {
+  background: var(--color-ivory);
+  color: var(--color-charcoal);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Cormorant Garamond", Georgia, serif;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import { Inter, Cormorant_Garamond } from 'next/font/google'
+import './globals.css'
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+const cormorant = Cormorant_Garamond({ subsets: ['latin'], variable: '--font-cormorant' })
+
+export const metadata: Metadata = {
+  title: 'Anderson Property Preservation',
+  description: 'Property preservation services for Columbus and nearby service areas.',
+}
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en" className={`${inter.variable} ${cormorant.variable}`}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <section className="mx-auto max-w-3xl px-4 py-20 text-center">
+      <h1 className="text-5xl font-semibold">404</h1>
+      <p className="mt-4">We couldn&apos;t find that page.</p>
+    </section>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://andersonpropertypreservation.com'
+
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next'
+
+const routes = [
+  '',
+  '/services',
+  '/property-cleanouts-columbus-ga',
+  '/junk-removal-columbus-ga',
+  '/lawn-overgrowth-cleanup-columbus-ga',
+  '/rental-turnover-cleanup-columbus-ga',
+  '/property-managers-investors',
+  '/service-areas',
+  '/service-areas/columbus-muscogee',
+  '/service-areas/harris-county-ga',
+  '/service-areas/russell-county-al',
+  '/before-after-gallery',
+  '/about',
+  '/request-estimate',
+  '/thank-you',
+  '/privacy-policy',
+]
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://andersonpropertypreservation.com'
+
+  return routes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+    changeFrequency: route === '' ? 'weekly' : 'monthly',
+    priority: route === '' ? 1 : 0.7,
+  }))
+}

--- a/components/site-shell.tsx
+++ b/components/site-shell.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+const navItems = [
+  { href: '/services', label: 'Services' },
+  { href: '/service-areas', label: 'Service Areas' },
+  { href: '/before-after-gallery', label: 'Gallery' },
+  { href: '/about', label: 'About' },
+  { href: '/request-estimate', label: 'Request Estimate' },
+]
+
+export function SiteShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[var(--color-ivory)] text-[var(--color-charcoal)]">
+      <header className="border-b border-[var(--color-stone)] bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 md:px-8">
+          <Link href="/" className="text-2xl font-semibold text-[var(--color-forest)]">
+            Anderson Property Preservation
+          </Link>
+          <nav aria-label="Main navigation">
+            <ul className="flex flex-wrap gap-3 text-sm md:gap-5">
+              {navItems.map((item) => (
+                <li key={item.href}>
+                  <Link href={item.href} className="rounded px-2 py-1 hover:text-[var(--color-forest)]">
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </header>
+      <main>{children}</main>
+      <footer className="border-t border-[var(--color-stone)] bg-white">
+        <div className="mx-auto max-w-6xl px-4 py-10 md:px-8">
+          <p className="text-sm">© {new Date().getFullYear()} Anderson Property Preservation</p>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/lib/payload/collections/estimate-submissions.ts
+++ b/lib/payload/collections/estimate-submissions.ts
@@ -1,0 +1,29 @@
+import type { CollectionConfig } from 'payload'
+
+export const EstimateSubmissions: CollectionConfig = {
+  slug: 'estimateSubmissions',
+  admin: { useAsTitle: 'contactName' },
+  fields: [
+    { name: 'contactName', type: 'text', required: true },
+    { name: 'email', type: 'email', required: true },
+    { name: 'phone', type: 'text' },
+    { name: 'serviceType', type: 'relationship', relationTo: 'services' },
+    { name: 'propertyAddress', type: 'textarea', required: true },
+    {
+      name: 'occupancyStatus',
+      type: 'select',
+      options: ['Occupied', 'Vacant', 'Unknown'],
+      required: true,
+    },
+    { name: 'timeline', type: 'text' },
+    { name: 'accessDetails', type: 'textarea' },
+    { name: 'payerApprover', type: 'text' },
+    { name: 'uploadKeys', type: 'array', fields: [{ name: 'key', type: 'text' }] },
+    {
+      name: 'status',
+      type: 'select',
+      defaultValue: 'new',
+      options: ['new', 'reviewing', 'quoted', 'closed'],
+    },
+  ],
+}

--- a/lib/payload/collections/faqs.ts
+++ b/lib/payload/collections/faqs.ts
@@ -1,0 +1,9 @@
+import type { CollectionConfig } from 'payload'
+
+export const Faqs: CollectionConfig = {
+  slug: 'faqs',
+  fields: [
+    { name: 'question', type: 'text', required: true },
+    { name: 'answer', type: 'textarea', required: true },
+  ],
+}

--- a/lib/payload/collections/gallery-items.ts
+++ b/lib/payload/collections/gallery-items.ts
@@ -1,0 +1,10 @@
+import type { CollectionConfig } from 'payload'
+
+export const GalleryItems: CollectionConfig = {
+  slug: 'galleryItems',
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'beforeImage', type: 'relationship', relationTo: 'media', required: true },
+    { name: 'afterImage', type: 'relationship', relationTo: 'media', required: true },
+  ],
+}

--- a/lib/payload/collections/media.ts
+++ b/lib/payload/collections/media.ts
@@ -1,0 +1,13 @@
+import type { CollectionConfig } from 'payload'
+
+export const Media: CollectionConfig = {
+  slug: 'media',
+  upload: true,
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/lib/payload/collections/pages.ts
+++ b/lib/payload/collections/pages.ts
@@ -1,0 +1,16 @@
+import type { CollectionConfig } from 'payload'
+import { seoFields } from '@/lib/payload/fields'
+
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  admin: { useAsTitle: 'title' },
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'slug', type: 'text', required: true, unique: true },
+    {
+      name: 'content',
+      type: 'richText',
+    },
+    ...seoFields,
+  ],
+}

--- a/lib/payload/collections/reviews.ts
+++ b/lib/payload/collections/reviews.ts
@@ -1,0 +1,10 @@
+import type { CollectionConfig } from 'payload'
+
+export const Reviews: CollectionConfig = {
+  slug: 'reviews',
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'rating', type: 'number', required: true, min: 1, max: 5 },
+    { name: 'review', type: 'textarea', required: true },
+  ],
+}

--- a/lib/payload/collections/service-areas.ts
+++ b/lib/payload/collections/service-areas.ts
@@ -1,0 +1,13 @@
+import type { CollectionConfig } from 'payload'
+import { seoFields } from '@/lib/payload/fields'
+
+export const ServiceAreas: CollectionConfig = {
+  slug: 'serviceAreas',
+  admin: { useAsTitle: 'name' },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'slug', type: 'text', required: true, unique: true },
+    { name: 'state', type: 'text', required: true },
+    ...seoFields,
+  ],
+}

--- a/lib/payload/collections/services.ts
+++ b/lib/payload/collections/services.ts
@@ -1,0 +1,13 @@
+import type { CollectionConfig } from 'payload'
+import { seoFields } from '@/lib/payload/fields'
+
+export const Services: CollectionConfig = {
+  slug: 'services',
+  admin: { useAsTitle: 'name' },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'slug', type: 'text', required: true, unique: true },
+    { name: 'summary', type: 'textarea', required: true },
+    ...seoFields,
+  ],
+}

--- a/lib/payload/collections/users.ts
+++ b/lib/payload/collections/users.ts
@@ -1,0 +1,13 @@
+import type { CollectionConfig } from 'payload'
+
+export const Users: CollectionConfig = {
+  slug: 'users',
+  auth: true,
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/lib/payload/fields.ts
+++ b/lib/payload/fields.ts
@@ -1,0 +1,14 @@
+import type { Field } from 'payload'
+
+export const seoFields: Field[] = [
+  {
+    name: 'seoTitle',
+    type: 'text',
+    required: true,
+  },
+  {
+    name: 'seoDescription',
+    type: 'textarea',
+    required: true,
+  },
+]

--- a/lib/payload/globals/footer-settings.ts
+++ b/lib/payload/globals/footer-settings.ts
@@ -1,0 +1,22 @@
+import type { GlobalConfig } from 'payload'
+
+export const FooterSettings: GlobalConfig = {
+  slug: 'footerSettings',
+  fields: [
+    { name: 'contactBlock', type: 'textarea' },
+    {
+      name: 'legalLinks',
+      type: 'array',
+      fields: [
+        { name: 'label', type: 'text', required: true },
+        { name: 'href', type: 'text', required: true },
+      ],
+    },
+    {
+      name: 'serviceAreaLinks',
+      type: 'relationship',
+      relationTo: 'serviceAreas',
+      hasMany: true,
+    },
+  ],
+}

--- a/lib/payload/globals/header-settings.ts
+++ b/lib/payload/globals/header-settings.ts
@@ -1,0 +1,17 @@
+import type { GlobalConfig } from 'payload'
+
+export const HeaderSettings: GlobalConfig = {
+  slug: 'headerSettings',
+  fields: [
+    { name: 'ctaPrimaryLabel', type: 'text', defaultValue: 'Request Estimate' },
+    { name: 'ctaSecondaryLabel', type: 'text', defaultValue: 'Call Now' },
+    {
+      name: 'navLinks',
+      type: 'array',
+      fields: [
+        { name: 'label', type: 'text', required: true },
+        { name: 'href', type: 'text', required: true },
+      ],
+    },
+  ],
+}

--- a/lib/payload/globals/homepage.ts
+++ b/lib/payload/globals/homepage.ts
@@ -1,0 +1,23 @@
+import type { GlobalConfig } from 'payload'
+
+export const Homepage: GlobalConfig = {
+  slug: 'homepage',
+  fields: [
+    { name: 'heroHeading', type: 'text', required: true },
+    { name: 'heroSubheading', type: 'textarea', required: true },
+    {
+      name: 'trustStripItems',
+      type: 'array',
+      fields: [{ name: 'item', type: 'text', required: true }],
+    },
+    {
+      name: 'processSteps',
+      type: 'array',
+      fields: [
+        { name: 'title', type: 'text', required: true },
+        { name: 'description', type: 'textarea', required: true },
+      ],
+    },
+    { name: 'finalCtaTitle', type: 'text' },
+  ],
+}

--- a/lib/payload/globals/site-settings.ts
+++ b/lib/payload/globals/site-settings.ts
@@ -1,0 +1,13 @@
+import type { GlobalConfig } from 'payload'
+
+export const SiteSettings: GlobalConfig = {
+  slug: 'siteSettings',
+  fields: [
+    { name: 'businessName', type: 'text', required: true },
+    { name: 'phone', type: 'text', required: true },
+    { name: 'hours', type: 'textarea' },
+    { name: 'primaryEmail', type: 'email', required: true },
+    { name: 'serviceRadiusBlurb', type: 'textarea' },
+    { name: 'defaultSeoImage', type: 'relationship', relationTo: 'media' },
+  ],
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+}
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "anderson-property-preservation",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": "20.x"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "payload": "payload"
+  },
+  "dependencies": {
+    "@payloadcms/next": "^3.0.0",
+    "@payloadcms/payload-cloud": "^3.0.0",
+    "@payloadcms/plugin-seo": "^3.0.0",
+    "next": "15.4.6",
+    "payload": "^3.0.0",
+    "pg": "^8.13.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "sharp": "^0.33.5",
+    "@payloadcms/db-postgres": "^3.0.0",
+    "@payloadcms/richtext-lexical": "^3.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "eslint": "^9.17.0",
+    "eslint-config-next": "15.4.6",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import { buildConfig } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+
+import { Media } from '@/lib/payload/collections/media'
+import { Pages } from '@/lib/payload/collections/pages'
+import { Services } from '@/lib/payload/collections/services'
+import { ServiceAreas } from '@/lib/payload/collections/service-areas'
+import { GalleryItems } from '@/lib/payload/collections/gallery-items'
+import { Reviews } from '@/lib/payload/collections/reviews'
+import { Faqs } from '@/lib/payload/collections/faqs'
+import { EstimateSubmissions } from '@/lib/payload/collections/estimate-submissions'
+import { Users } from '@/lib/payload/collections/users'
+import { SiteSettings } from '@/lib/payload/globals/site-settings'
+import { HeaderSettings } from '@/lib/payload/globals/header-settings'
+import { FooterSettings } from '@/lib/payload/globals/footer-settings'
+import { Homepage } from '@/lib/payload/globals/homepage'
+
+export default buildConfig({
+  editor: lexicalEditor(),
+  secret: process.env.PAYLOAD_SECRET || 'dev-secret-change-me',
+  admin: {
+    user: Users.slug,
+    importMap: {
+      baseDir: path.resolve(),
+    },
+  },
+  db: postgresAdapter({
+    pool: {
+      connectionString: process.env.DATABASE_URL,
+    },
+  }),
+  collections: [Users, Media, Pages, Services, ServiceAreas, GalleryItems, Reviews, Faqs, EstimateSubmissions],
+  globals: [SiteSettings, HeaderSettings, FooterSettings, Homepage],
+  typescript: {
+    outputFile: path.resolve(__dirname, 'payload-types.ts'),
+  },
+})

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}
+
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ],
+      "@payload-config": [
+        "./payload.config.ts"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a production-aligned single-repo scaffold that implements the chosen stack (Next.js App Router, embedded Payload CMS, Tailwind CSS, Postgres, S3, SES) and pins versions safe for AWS Amplify deployment.  
- Establish the content model and route topology so editors and developers can iterate from a consistent baseline.  
- Add operational and SEO scaffolding (sitemap, robots, env template) and placeholders for the estimate upload / submission flows to guide next integration steps.  
- Keep the initial scaffold minimal and explicit so subsequent PRs can implement Payload admin wiring, S3 pre-signed uploads, and SES notifications incrementally.  

### Description
- Pinned runtime and deps in `package.json` (Node 20.x, Next 15.4.6) and added scripts for `dev`, `build`, `start`, `lint`, and `payload`.  
- Scaffolded Next.js App Router routes, `app` layout, `SiteShell` component, global Tailwind tokens in `app/globals.css`, and the full public route map requested (homepage, services, service-areas, gallery, about, request-estimate, thank-you, privacy-policy, etc.).  
- Added a Payload scaffold with `payload.config.ts` (Postgres adapter + lexical editor), collection definitions in `lib/payload/collections/*`, globals in `lib/payload/globals/*`, and shared `seoFields`.  
- Added API placeholders `app/api/uploads/presign/route.ts` and `app/api/estimates/route.ts` that return `501` with implementation notes, plus `app/api/health/route.ts`, `app/sitemap.ts`, `app/robots.ts`, `.env.example`, and an updated `README.md` documenting next milestones.  

### Testing
- Ran `npm install`, which failed due to a registry/network policy returning `403 Forbidden` so dependency installation and build checks could not be completed.  
- Ran `node -e "..."` JSON validation of `package.json` and `tsconfig.json`, which succeeded (`json-ok`).  
- Verified route/file scaffold with `rg --files app | wc -l`, which succeeded and reported the scaffolded files (26 entries counted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83c159350832ba378c2d58aafaf4a)